### PR TITLE
[bugfix]#BOSQ-468 태광 이슈 수정

### DIFF
--- a/src/features/auth/hooks/useApiForLogin.ts
+++ b/src/features/auth/hooks/useApiForLogin.ts
@@ -6,11 +6,13 @@ import { loginApi } from '../api/login';
 import { UseMutationOptions } from '@tanstack/react-query';
 import { LoginCredentials, LoginResponse, AuthApiError } from '../types/loginIndex';
 import { useTabStore } from '@/store/tabStore'; // 탭 초기화를 위한 store import
+import { useCampainManagerStore } from '@/store';
 
 export function useApiForLogin(
   options?: UseMutationOptions<LoginResponse, AuthApiError, LoginCredentials>
 ) {
   const resetTabStore = useTabStore((state) => state.resetTabStore); // 초기화 함수 가져오기
+  const setResetCampaignManagerStore = useCampainManagerStore((state) => state.setResetCampaignManagerStore);
 
   return useMutation({
     mutationKey: ['login'],
@@ -18,6 +20,8 @@ export function useApiForLogin(
     onSuccess: (data, variables, context) => {
       // ✅ 로그인 성공 시 탭 관련 상태 초기화
       resetTabStore();
+      // ✅ 캠페인 매니저 store 초기화 (이전 사용자의 copy* 잔존 데이터 방지)
+      setResetCampaignManagerStore();
 
       // 기존 옵션 실행
       options?.onSuccess?.(data, variables, context);

--- a/src/widgets/sidebar2/pannels/CampaignCloneDetail.tsx
+++ b/src/widgets/sidebar2/pannels/CampaignCloneDetail.tsx
@@ -895,6 +895,18 @@ export default function CampaignDetail() {
         onClose: () => setAlertState((prev) => ({ ...prev, isOpen: false }))
       });
     }
+
+    // # BOSQ-468 태광 요청으로 캠페인ID 자동생성에서 무조건 입력으로 유효성 추가 2026/04/23 - by rody
+    if(!saveErrorCheck && (copyCampaignManagerInfo.campaign_id <= 0 || inputCampaignId === '') ){
+      saveErrorCheck = true;
+      setAlertState({
+        ...errorMessage,
+        isOpen: true,
+        message: "캠페인 아이디를 입력해 주세요.",
+        type: '2',
+        onClose: () => setAlertState((prev) => ({ ...prev, isOpen: false }))
+      });
+    }
     if( !saveErrorCheck && copyCampaignManagerInfo.campaign_id > 0 ){
       const checkCampaign = campaigns.filter(data => data.campaign_id === copyCampaignManagerInfo.campaign_id);
       if( checkCampaign.length > 0 ){


### PR DESCRIPTION
● 작업자 : rody
● 작업내용 : 태광 이슈 수정
- 캠페인 복사 사용 시 캠페인 아이디 미입력하는 경우 알림 팝업 추가
- 로그인 시 캠페인복사 저장데이터 초기화 방어코드 추가